### PR TITLE
Add seamless polygon border line

### DIFF
--- a/addons/antialiased_line2d/antialiased_line2d.gd
+++ b/addons/antialiased_line2d/antialiased_line2d.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 static func construct_closed_line(p_polygon: PoolVector2Array) -> PoolVector2Array:
 	var end_point: Vector2 = p_polygon[p_polygon.size() - 1]
 	var distance: float = end_point.distance_to(p_polygon[0]) # distance to start point
-	var bridge_point: Vector2 = end_point.move_toward(p_polygon[0], distance / 2.0)
+	var bridge_point: Vector2 = end_point.move_toward(p_polygon[0], distance * 0.5)
 	# Close the polygon drawn by the line by adding superimposed bridge points between the start and end points.
 	var polygon_line := p_polygon
 	polygon_line.push_back(bridge_point)

--- a/addons/antialiased_line2d/antialiased_line2d.gd
+++ b/addons/antialiased_line2d/antialiased_line2d.gd
@@ -6,3 +6,14 @@ extends Line2D
 func _ready() -> void:
 	texture = AntialiasedLine2DTexture.texture
 	texture_mode = Line2D.LINE_TEXTURE_TILE
+
+
+static func construct_closed_line(p_polygon: PoolVector2Array) -> PoolVector2Array:
+	var end_point: Vector2 = p_polygon[p_polygon.size() - 1]
+	var distance: float = end_point.distance_to(p_polygon[0]) # distance to start point
+	var bridge_point: Vector2 = end_point.move_toward(p_polygon[0], distance / 2.0)
+	# Close the polygon drawn by the line by adding superimposed bridge points between the start and end points.
+	var polygon_line := p_polygon
+	polygon_line.push_back(bridge_point)
+	polygon_line.insert(0, bridge_point)
+	return polygon_line

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -16,25 +16,14 @@ var line_2d := Line2D.new()
 func _ready() -> void:
 	line_2d.texture = AntialiasedLine2DTexture.texture
 	line_2d.texture_mode = Line2D.LINE_TEXTURE_TILE
-	# Make the closed polyline look more closed.
-	line_2d.begin_cap_mode = Line2D.LINE_CAP_ROUND
-
-	# Close the polygon drawn by the line by adding the first point to the end.
-	var polygon_line := polygon
 	if polygon.size() >= 1:
-		polygon_line.push_back(polygon[0])
-	line_2d.points = polygon_line
-
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 	add_child(line_2d)
-
-
+	
+	
 func _set(property: String, value) -> bool:
 	if property == "polygon":
-		# Close the polygon drawn by the line by adding the first point to the end.
-		var polygon_line := polygon
-		polygon_line.push_back(polygon[0])
-		line_2d.points = polygon_line
-
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 	return false
 
 

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -19,8 +19,8 @@ func _ready() -> void:
 	if polygon.size() >= 1:
 		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 	add_child(line_2d)
-	
-	
+
+
 func _set(property: String, value) -> bool:
 	if property == "polygon":
 		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)

--- a/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
@@ -20,21 +20,13 @@ var line_2d := Line2D.new()
 func _ready() -> void:
 	line_2d.texture = AntialiasedLine2DTexture.texture
 	line_2d.texture_mode = Line2D.LINE_TEXTURE_TILE
-	# Make the closed polyline look more closed.
-	line_2d.begin_cap_mode = Line2D.LINE_CAP_ROUND
-
 	update_points()
-
 	add_child(line_2d)
 
 
 func _set(property: String, value) -> bool:
 	if property == "polygon":
-		# Close the polygon drawn by the line by adding the first point to the end.
-		var polygon_line := polygon
-		polygon_line.push_back(polygon[0])
-		line_2d.points = polygon_line
-
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 	return false
 
 
@@ -45,12 +37,8 @@ func update_points() -> void:
 	if not is_equal_approx(angle_degrees, 360.0):
 		points.push_back(Vector2.ZERO)
 	polygon = points
-
 	# Force an update of the Line2D here to prevent it from getting out of sync.
-	# Close the polygon drawn by the line by adding the first point to the end.
-	var polygon_line := polygon
-	polygon_line.push_back(polygon[0])
-	line_2d.points = polygon_line
+	line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 
 
 func set_size(p_size: Vector2) -> void:


### PR DESCRIPTION
This commit eliminates the visible defect in the polygon border line where it formerly closed with a rounded end.

It does this by computing a bridge point midway between the start and end points and adding this point to the beginning and end of the PoolVector2Array defining the line. The butt ends of the line then always meet orthogonally and thus invisibly.