### PR TITLE
Port to Godot 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Antialiased Line2D add-on for Godot 3.x
+# Antialiased Line2D add-on for Godot 4.x
 
 ![Screenshot](https://raw.githubusercontent.com/Calinou/media/master/godot-antialiased-line2d-demo/screenshot.png)
 

--- a/addons/antialiased_line2d/antialiased_line2d.gd
+++ b/addons/antialiased_line2d/antialiased_line2d.gd
@@ -1,14 +1,13 @@
-tool
-class_name AntialiasedLine2D, "antialiased_line2d.svg"
+@tool
+class_name AntialiasedLine2D
 extends Line2D
-
 
 func _ready() -> void:
 	texture = AntialiasedLine2DTexture.texture
 	texture_mode = Line2D.LINE_TEXTURE_TILE
+	texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
 
-
-static func construct_closed_line(p_polygon: PoolVector2Array) -> PoolVector2Array:
+static func construct_closed_line(p_polygon: PackedVector2Array) -> PackedVector2Array:
 	var end_point: Vector2 = p_polygon[p_polygon.size() - 1]
 	var distance: float = end_point.distance_to(p_polygon[0]) # distance to start point
 	var bridge_point: Vector2 = end_point.move_toward(p_polygon[0], distance * 0.5)

--- a/addons/antialiased_line2d/antialiased_line2d.svg.import
+++ b/addons/antialiased_line2d/antialiased_line2d.svg.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/antialiased_line2d.svg-9243613cd101e058db6c37ff468932c4.stex"
+type="CompressedTexture2D"
+uid="uid://guodfckewtpv"
+path="res://.godot/imported/antialiased_line2d.svg-9243613cd101e058db6c37ff468932c4.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,27 @@ metadata={
 [deps]
 
 source_file="res://addons/antialiased_line2d/antialiased_line2d.svg"
-dest_files=[ "res://.import/antialiased_line2d.svg-9243613cd101e058db6c37ff468932c4.stex" ]
+dest_files=["res://.godot/imported/antialiased_line2d.svg-9243613cd101e058db6c37ff468932c4.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
 svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -1,29 +1,29 @@
 # This is a convenience node that automatically synchronizes an AntialiasedLine2D
 # with a Polygon2D.
-tool
-class_name AntialiasedPolygon2D, "antialiased_polygon2d.svg"
+@tool
+class_name AntialiasedPolygon2D
 extends Polygon2D
 
-export var stroke_color := Color(0.4, 0.5, 1.0) setget set_stroke_color
-export(float, 0.0, 1000.0) var stroke_width := 10.0 setget set_stroke_width
-export(int, "Sharp", "Bevel", "Round") var stroke_joint_mode := Line2D.LINE_JOINT_SHARP setget set_stroke_joint_mode
-export(float, 0.0, 1000.0) var stroke_sharp_limit := 2.0 setget set_stroke_sharp_limit
-export(int, 1, 32) var stroke_round_precision := 8 setget set_stroke_round_precision
+@export var stroke_color := Color(0.4, 0.5, 1.0): set = set_stroke_color
+@export_range(0.0, 1000.0) var stroke_width:float = 10.0: set = set_stroke_width
+@export var stroke_joint_mode:Line2D.LineJointMode = Line2D.LINE_JOINT_SHARP: set = set_stroke_joint_mode
+@export_range(0.0, 1000.0) var stroke_sharp_limit:float = 2.0: set = set_stroke_sharp_limit
+@export_range(1, 32) var stroke_round_precision: int = 8: set = set_stroke_round_precision
 
 var line_2d := Line2D.new()
-
 
 func _ready() -> void:
 	line_2d.texture = AntialiasedLine2DTexture.texture
 	line_2d.texture_mode = Line2D.LINE_TEXTURE_TILE
+	line_2d.texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
 	if polygon.size() >= 1:
 		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 	add_child(line_2d)
 
 
-func _set(property: String, value) -> bool:
+func _set(property, value) -> bool:
 	if property == "polygon":
-		line_2d.points = AntialiasedLine2D.construct_closed_line(value)
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
 	return false
 
 
@@ -37,7 +37,7 @@ func set_stroke_width(p_stroke_width: float) -> void:
 	line_2d.width = stroke_width
 
 
-func set_stroke_joint_mode(p_stroke_joint_mode: int) -> void:
+func set_stroke_joint_mode(p_stroke_joint_mode: Line2D.LineJointMode) -> void:
 	stroke_joint_mode = p_stroke_joint_mode
 	line_2d.joint_mode = stroke_joint_mode
 

--- a/addons/antialiased_line2d/antialiased_polygon2d.svg.import
+++ b/addons/antialiased_line2d/antialiased_polygon2d.svg.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/antialiased_polygon2d.svg-d9d32c42c22022e4f4053cee124a07c0.stex"
+type="CompressedTexture2D"
+uid="uid://bkfc7y0qnfi4a"
+path="res://.godot/imported/antialiased_polygon2d.svg-d9d32c42c22022e4f4053cee124a07c0.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,27 @@ metadata={
 [deps]
 
 source_file="res://addons/antialiased_line2d/antialiased_polygon2d.svg"
-dest_files=[ "res://.import/antialiased_polygon2d.svg-d9d32c42c22022e4f4053cee124a07c0.stex" ]
+dest_files=["res://.godot/imported/antialiased_polygon2d.svg-d9d32c42c22022e4f4053cee124a07c0.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
 svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
@@ -1,39 +1,38 @@
 # This is a convenience node that automatically synchronizes an AntialiasedLine2D
 # with a Polygon2D, while also generating a regular Polygon2D shape (hexagon, octagon, …).
-tool
-class_name AntialiasedRegularPolygon2D, "antialiased_regular_polygon2d.svg"
+@tool
+class_name AntialiasedRegularPolygon2D
 extends Polygon2D
 
-export var size := Vector2(64, 64) setget set_size
-export(int, 3, 128) var sides := 32 setget set_sides
-export(float, 0.0, 360.0) var angle_degrees := 360.0 setget set_angle_degrees
-
-export var stroke_color := Color(0.4, 0.5, 1.0) setget set_stroke_color
-export(float, 0.0, 1000.0) var stroke_width := 10.0 setget set_stroke_width
-export(int, "Sharp", "Bevel", "Round") var stroke_joint_mode := Line2D.LINE_JOINT_SHARP setget set_stroke_joint_mode
-export(float, 0.0, 1000.0) var stroke_sharp_limit := 2.0 setget set_stroke_sharp_limit
-export(int, 1, 32) var stroke_round_precision := 8 setget set_stroke_round_precision
+@export var size := Vector2(64, 64): set = set_size
+@export_range(3, 128) var sides: int = 32: set = set_sides
+@export_range(0.0, 360.0) var angle_degrees: float = 360: set = set_angle_degrees
+@export var stroke_color := Color(0.4, 0.5, 1.0): set = set_stroke_color
+@export_range(0.0, 1000.0) var stroke_width:float = 10.0: set = set_stroke_width
+@export var stroke_joint_mode:Line2D.LineJointMode = Line2D.LINE_JOINT_SHARP: set = set_stroke_joint_mode
+@export_range(0.0, 1000.0) var stroke_sharp_limit:float = 2.0: set = set_stroke_sharp_limit
+@export_range(1, 32) var stroke_round_precision: int = 8: set = set_stroke_round_precision
 
 var line_2d := Line2D.new()
-
 
 func _ready() -> void:
 	line_2d.texture = AntialiasedLine2DTexture.texture
 	line_2d.texture_mode = Line2D.LINE_TEXTURE_TILE
+	line_2d.texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
 	update_points()
 	add_child(line_2d)
 
 
-func _set(property: String, value) -> bool:
+func _set(property, value) -> bool:
 	if property == "polygon":
 		line_2d.points = AntialiasedLine2D.construct_closed_line(value)
 	return false
 
 
 func update_points() -> void:
-	var points := PoolVector2Array()
+	var points := PackedVector2Array()
 	for side in sides:
-		points.push_back(Vector2(0, -1).rotated(side / float(sides) * deg2rad(angle_degrees)) * size * 0.5)
+		points.push_back(Vector2(0, -1).rotated(side / float(sides) * deg_to_rad(angle_degrees)) * size * 0.5)
 	if not is_equal_approx(angle_degrees, 360.0):
 		points.push_back(Vector2.ZERO)
 	polygon = points
@@ -60,13 +59,12 @@ func set_stroke_color(p_stroke_color: Color) -> void:
 	stroke_color = p_stroke_color
 	line_2d.default_color = stroke_color
 
-
 func set_stroke_width(p_stroke_width: float) -> void:
 	stroke_width = p_stroke_width
 	line_2d.width = stroke_width
 
 
-func set_stroke_joint_mode(p_stroke_joint_mode: int) -> void:
+func set_stroke_joint_mode(p_stroke_joint_mode: Line2D.LineJointMode) -> void:
 	stroke_joint_mode = p_stroke_joint_mode
 	line_2d.joint_mode = stroke_joint_mode
 

--- a/addons/antialiased_line2d/antialiased_regular_polygon2d.svg.import
+++ b/addons/antialiased_line2d/antialiased_regular_polygon2d.svg.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/antialiased_regular_polygon2d.svg-90c0efb58c0991f1567ca6f17fea2cda.stex"
+type="CompressedTexture2D"
+uid="uid://cypudkhnexspo"
+path="res://.godot/imported/antialiased_regular_polygon2d.svg-90c0efb58c0991f1567ca6f17fea2cda.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,26 +11,27 @@ metadata={
 [deps]
 
 source_file="res://addons/antialiased_line2d/antialiased_regular_polygon2d.svg"
-dest_files=[ "res://.import/antialiased_regular_polygon2d.svg-90c0efb58c0991f1567ca6f17fea2cda.stex" ]
+dest_files=["res://.godot/imported/antialiased_regular_polygon2d.svg-90c0efb58c0991f1567ca6f17fea2cda.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
 process/normal_map_invert_y=false
-stream=false
-size_limit=0
-detect_3d=true
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
 svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/addons/antialiased_line2d/plugin.gd
+++ b/addons/antialiased_line2d/plugin.gd
@@ -1,9 +1,20 @@
-tool
+@tool
 extends EditorPlugin
-
 
 func _enter_tree() -> void:
 	add_autoload_singleton("AntialiasedLine2DTexture", "res://addons/antialiased_line2d/texture.gd")
+	# Register line 2D type & its icon
+	add_custom_type("AntialiasedLine2D", "Line2D", 
+	preload("res://addons/antialiased_line2d/antialiased_line2d.gd"), 
+	preload("res://addons/antialiased_line2d/antialiased_line2d.svg"))
+	# Polygon 2D
+	add_custom_type("AntialiasedPolygon2D", "Polygon2D", 
+	preload("res://addons/antialiased_line2d/antialiased_polygon2d.gd"), 
+	preload("res://addons/antialiased_line2d/antialiased_polygon2d.svg"))
+	# # Regular Polygon 2D
+	add_custom_type("AntialiasedRegularPolygon2D", "Polygon2D", 
+	preload("res://addons/antialiased_line2d/antialiased_regular_polygon2d.gd"), 
+	preload("res://addons/antialiased_line2d/antialiased_regular_polygon2d.svg"))
 
 
 func _exit_tree() -> void:

--- a/addons/antialiased_line2d/texture.gd
+++ b/addons/antialiased_line2d/texture.gd
@@ -1,4 +1,4 @@
-tool
+@tool
 extends Node
 
 # Generates the antialiased Line2D texture that will be used by the various nodes.
@@ -6,14 +6,13 @@ extends Node
 # for every AntialiasedLine2D node. This generation can take several dozen milliseconds,
 # so it would cause stuttering if performed during gameplay.
 
-var texture := ImageTexture.new()
-
+var texture:ImageTexture = null
 
 func _ready() -> void:
 	# Generate a texture with custom mipmaps (1-pixel feather on the top and bottom sides).
 	# The texture must be square for mipmaps to work correctly. The texture's in-memory size is still
 	# pretty low (less than 200 KB), so this should not cause any performance problems.
-	var data := PoolByteArray()
+	var data := PackedByteArray()
 	for mipmap in [256, 128, 64, 32, 16, 8, 4, 2, 1]:
 		for y in mipmap:
 			for x in mipmap:
@@ -42,6 +41,5 @@ func _ready() -> void:
 					# Average of 0 and 255 (there is only one pixel).
 					data.push_back(128)
 
-	var image := Image.new()
-	image.create_from_data(256, 256, true, Image.FORMAT_LA8, data)
-	texture.create_from_image(image)
+	var image = Image.create_from_data(256, 256, true, Image.FORMAT_LA8, data)
+	texture = ImageTexture.create_from_image(image)


### PR DESCRIPTION
Updates this add on for Godot 4 (https://github.com/godot-extended-libraries/godot-antialiased-line2d/issues/5). This is NOT backwards compatible, so not sure if we'd want to restructure the repo to have a `godot4` folder? Or just make the Godot 4 the canonical one and keep the 3.x version on a branch?

### See the 4.0 ported demo project here: https://github.com/godot-extended-libraries/godot-antialiased-line2d-demo/pull/1

90% of the changes here are just the 3.x -> 4.x syntax.  One thing I had to add was explicitly setting the texture filter:

```
texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS
```