### PR TITLE
Add width_curve and offset

### DIFF
--- a/addons/antialiased_line2d/antialiased_line2d.gd
+++ b/addons/antialiased_line2d/antialiased_line2d.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 	texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
 
 
-static func construct_closed_line(p_polygon: PackedVector2Array,offset:=Vector2.ZERO) -> PackedVector2Array:
+static func construct_closed_line(p_polygon: PackedVector2Array, offset = Vector2.ZERO) -> PackedVector2Array:
 	var end_point: Vector2 = p_polygon[p_polygon.size() - 1]
 	var distance: float = end_point.distance_to(p_polygon[0]) # distance to start point
 	var bridge_point: Vector2 = end_point.move_toward(p_polygon[0], distance * 0.5)

--- a/addons/antialiased_line2d/antialiased_line2d.gd
+++ b/addons/antialiased_line2d/antialiased_line2d.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 	texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
 
 
-static func construct_closed_line(p_polygon: PackedVector2Array) -> PackedVector2Array:
+static func construct_closed_line(p_polygon: PackedVector2Array,offset:=Vector2.ZERO) -> PackedVector2Array:
 	var end_point: Vector2 = p_polygon[p_polygon.size() - 1]
 	var distance: float = end_point.distance_to(p_polygon[0]) # distance to start point
 	var bridge_point: Vector2 = end_point.move_toward(p_polygon[0], distance * 0.5)

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -10,6 +10,7 @@ extends Polygon2D
 @export var stroke_joint_mode:Line2D.LineJointMode = Line2D.LINE_JOINT_SHARP: set = set_stroke_joint_mode
 @export_range(0.0, 1000.0) var stroke_sharp_limit:float = 2.0: set = set_stroke_sharp_limit
 @export_range(1, 32) var stroke_round_precision: int = 8: set = set_stroke_round_precision
+@export var stroke_width_curve : Curve: set = set_stroke_width_curve
 
 var line_2d := Line2D.new()
 
@@ -18,14 +19,17 @@ func _ready() -> void:
 	line_2d.texture = AntialiasedLine2DTexture.texture
 	line_2d.texture_mode = Line2D.LINE_TEXTURE_TILE
 	line_2d.texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
+	line_2d.position = offset
 	if polygon.size() >= 1:
-		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon,offset)
 	add_child(line_2d)
 
 
 func _set(property: StringName, value: Variant) -> bool:
 	if property == &"polygon":
-		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon,offset)
+	elif property == &"offset":
+		line_2d.position = value
 
 	return false
 
@@ -53,3 +57,7 @@ func set_stroke_sharp_limit(p_stroke_sharp_limit: float) -> void:
 func set_stroke_round_precision(p_stroke_round_precision: int) -> void:
 	stroke_round_precision = p_stroke_round_precision
 	line_2d.round_precision = stroke_round_precision
+
+func set_stroke_width_curve(p_stroke_width_curve: Curve) -> void:
+	stroke_width_curve = p_stroke_width_curve
+	line_2d.width_curve = p_stroke_width_curve

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -58,8 +58,7 @@ func set_stroke_round_precision(p_stroke_round_precision: int) -> void:
 	stroke_round_precision = p_stroke_round_precision
 	line_2d.round_precision = stroke_round_precision
 
-func set_stroke_width_curve(p_stroke_width_curve: Curve) -> void:
-
 
 func set_stroke_width_curve(p_stroke_width_curve: Curve) -> void:
+	stroke_width_curve = p_stroke_width_curve
 	line_2d.width_curve = p_stroke_width_curve

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -10,7 +10,7 @@ extends Polygon2D
 @export var stroke_joint_mode:Line2D.LineJointMode = Line2D.LINE_JOINT_SHARP: set = set_stroke_joint_mode
 @export_range(0.0, 1000.0) var stroke_sharp_limit:float = 2.0: set = set_stroke_sharp_limit
 @export_range(1, 32) var stroke_round_precision: int = 8: set = set_stroke_round_precision
-@export var stroke_width_curve : Curve: set = set_stroke_width_curve
+@export var stroke_width_curve: Curve: set = set_stroke_width_curve
 
 var line_2d := Line2D.new()
 
@@ -21,13 +21,13 @@ func _ready() -> void:
 	line_2d.texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
 	line_2d.position = offset
 	if polygon.size() >= 1:
-		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon,offset)
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon, offset)
 	add_child(line_2d)
 
 
 func _set(property: StringName, value: Variant) -> bool:
 	if property == &"polygon":
-		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon,offset)
+		line_2d.points = AntialiasedLine2D.construct_closed_line(polygon, offset)
 	elif property == &"offset":
 		line_2d.position = value
 

--- a/addons/antialiased_line2d/antialiased_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_polygon2d.gd
@@ -59,5 +59,7 @@ func set_stroke_round_precision(p_stroke_round_precision: int) -> void:
 	line_2d.round_precision = stroke_round_precision
 
 func set_stroke_width_curve(p_stroke_width_curve: Curve) -> void:
-	stroke_width_curve = p_stroke_width_curve
+
+
+func set_stroke_width_curve(p_stroke_width_curve: Curve) -> void:
 	line_2d.width_curve = p_stroke_width_curve

--- a/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
@@ -13,7 +13,7 @@ extends Polygon2D
 @export var stroke_joint_mode:Line2D.LineJointMode = Line2D.LINE_JOINT_SHARP: set = set_stroke_joint_mode
 @export_range(0.0, 1000.0) var stroke_sharp_limit:float = 2.0: set = set_stroke_sharp_limit
 @export_range(1, 32) var stroke_round_precision: int = 8: set = set_stroke_round_precision
-@export var stroke_width_curve : Curve: set = set_stroke_width_curve
+@export var stroke_width_curve: Curve: set = set_stroke_width_curve
 
 var line_2d := Line2D.new()
 
@@ -44,7 +44,7 @@ func update_points() -> void:
 		points.push_back(Vector2.ZERO)
 	polygon = points
 	# Force an update of the Line2D here to prevent it from getting out of sync.
-	line_2d.points = AntialiasedLine2D.construct_closed_line(polygon,offset)
+	line_2d.points = AntialiasedLine2D.construct_closed_line(polygon, offset)
 
 
 func set_size(p_size: Vector2) -> void:

--- a/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
+++ b/addons/antialiased_line2d/antialiased_regular_polygon2d.gd
@@ -13,6 +13,7 @@ extends Polygon2D
 @export var stroke_joint_mode:Line2D.LineJointMode = Line2D.LINE_JOINT_SHARP: set = set_stroke_joint_mode
 @export_range(0.0, 1000.0) var stroke_sharp_limit:float = 2.0: set = set_stroke_sharp_limit
 @export_range(1, 32) var stroke_round_precision: int = 8: set = set_stroke_round_precision
+@export var stroke_width_curve : Curve: set = set_stroke_width_curve
 
 var line_2d := Line2D.new()
 
@@ -21,13 +22,16 @@ func _ready() -> void:
 	line_2d.texture = AntialiasedLine2DTexture.texture
 	line_2d.texture_mode = Line2D.LINE_TEXTURE_TILE
 	line_2d.texture_filter = TextureFilter.TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC
+	line_2d.position = offset
 	update_points()
 	add_child(line_2d)
 
 
 func _set(property: StringName, value: Variant) -> bool:
 	if property == &"polygon":
-		line_2d.points = AntialiasedLine2D.construct_closed_line(value)
+		line_2d.points = AntialiasedLine2D.construct_closed_line(value,offset)
+	elif property == &"offset":
+		line_2d.position = value
 
 	return false
 
@@ -40,7 +44,7 @@ func update_points() -> void:
 		points.push_back(Vector2.ZERO)
 	polygon = points
 	# Force an update of the Line2D here to prevent it from getting out of sync.
-	line_2d.points = AntialiasedLine2D.construct_closed_line(polygon)
+	line_2d.points = AntialiasedLine2D.construct_closed_line(polygon,offset)
 
 
 func set_size(p_size: Vector2) -> void:
@@ -80,3 +84,7 @@ func set_stroke_sharp_limit(p_stroke_sharp_limit: float) -> void:
 func set_stroke_round_precision(p_stroke_round_precision: int) -> void:
 	stroke_round_precision = p_stroke_round_precision
 	line_2d.round_precision = stroke_round_precision
+
+func set_stroke_width_curve(p_stroke_width_curve: Curve) -> void:
+	stroke_width_curve = p_stroke_width_curve
+	line_2d.width_curve = p_stroke_width_curve


### PR DESCRIPTION
Adds a property for `Line2D.width_curve` and offsets the Line2D according to `Polygon2D.offset`.

Before:
<img width="1180" height="836" alt="image" src="https://github.com/user-attachments/assets/883d56cc-6c64-42b7-b099-b8e1f5f197d8" />

After:
<img width="1180" height="836" alt="image" src="https://github.com/user-attachments/assets/ccfa414e-b78e-4884-9f5e-4e728b9fae80" />
